### PR TITLE
Added Kali Linux Distribution Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Using `os_type::current_platform().os_type`, expect one of these return values:
 - Manjaro
 - Alpine
 - Deepin
+- Kali
 
 If you need support for more OS types, please consider opening a Pull Request.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,7 @@ pub enum OSType {
     OpenSUSE,
     Alpine,
     Deepin,
+    Kali,
 }
 
 /// Holds information about Operating System type and its version
@@ -170,8 +171,12 @@ fn os_release() -> OSInformation {
                         os_type: OSType::Deepin,
                         version: release.version.unwrap_or(default_version()),
                     }
-                }
-                else {
+                } else if distro.starts_with("Kali") {
+                    OSInformation {
+                        os_type: OSType::Kali,
+                        version: release.version.unwrap_or(default_version()),
+                    }
+                } else {
                     unknown_os()
                 }
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,6 +102,11 @@ fn lsb_release() -> OSInformation {
                     os_type: OSType::OpenSUSE,
                     version: release.version.unwrap_or(default_version())
                 }
+            } else if release.distro == Some("Kali".to_string()) {
+                OSInformation {
+                    os_type: OSType::Kali,
+                    version: release.version.unwrap_or(default_version())
+                }
             }
             else {
                 unknown_os()

--- a/src/os_release.rs
+++ b/src/os_release.rs
@@ -124,4 +124,27 @@ mod tests {
             }
         );
     }
+
+    #[test]
+    fn parse_kali_2021_4_os_release() {
+        let sample = "\
+        NAME=\"Kali GNU/Linux\"\
+        VERSION=\"2021.4\"
+        ID=kali
+        ID_LIKE=debian
+        PRETTY_NAME=\"Kali Linux GNU/Linux Rolling\"\
+        VERSION_ID=\"2021.4\"\
+        HOME_URL=\"https://www.kali.org/\"\
+        SUPPORT_URL=\"https://forums.kali.org/\"\
+        BUG_REPORT_URL=\"https://bugs.kali.org\"\
+        ".to_string();
+
+        assert_eq!(
+            parse(sample),
+            OSRelease {
+                distro: Some("Kali".to_string()),
+                version: Some("2021.4".to_string()),
+            }
+        );
+    }
 }

--- a/src/os_release.rs
+++ b/src/os_release.rs
@@ -129,7 +129,7 @@ mod tests {
     fn parse_kali_2021_4_os_release() {
         let sample = "\
         PRETTY_NAME=\"Kali Linux GNU/Linux Rolling\"
-        NAME=\"Kali GNU/Linux\"
+        NAME=\"Kali\"
         ID=kali
         VERSION=\"2021.4\"
         VERSION_ID=\"2021.4\"

--- a/src/os_release.rs
+++ b/src/os_release.rs
@@ -128,15 +128,16 @@ mod tests {
     #[test]
     fn parse_kali_2021_4_os_release() {
         let sample = "\
-        NAME=\"Kali GNU/Linux\"\
-        VERSION=\"2021.4\"
+        PRETTY_NAME=\"Kali Linux GNU/Linux Rolling\"
+        NAME=\"Kali GNU/Linux\"
         ID=kali
+        VERSION=\"2021.4\"
+        VERSION_ID=\"2021.4\"
+        VERSION_CODENAME=\"kali-rolling\"
         ID_LIKE=debian
-        PRETTY_NAME=\"Kali Linux GNU/Linux Rolling\"\
-        VERSION_ID=\"2021.4\"\
-        HOME_URL=\"https://www.kali.org/\"\
-        SUPPORT_URL=\"https://forums.kali.org/\"\
-        BUG_REPORT_URL=\"https://bugs.kali.org\"\
+        HOME_URL=\"https://www.kali.org/\"
+        SUPPORT_URL=\"https://forums.kali.org/\"
+        BUG_REPORT_URL=\"https://bugs.kali.org\"
         ".to_string();
 
         assert_eq!(


### PR DESCRIPTION
This PR includes Kali Linux support. Now recognizes the Kali Linux distribution when attempting to access the os_type or version. Kali Linux is not currently supported.

Found this to be a better solution than running process::Command against etc/os-release every time.